### PR TITLE
No longer respond to bots

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -5,6 +5,8 @@ pub mod issue;
 pub mod code;
 
 pub async fn message(ctx: &Context, msg: &Message) {
-  issue::message(&ctx, &msg).await;
-  code::message(&ctx, &msg).await;
+  if !msg.author.bot {
+    issue::message(&ctx, &msg).await;
+    code::message(&ctx, &msg).await;
+  }
 }


### PR DESCRIPTION
Messages from bots, including itself, were able to trigger event message responses.