### PR TITLE
Fix various problems and override specific framework errors.

### DIFF
--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -379,7 +379,7 @@ pub async fn list_repos(ctx: Context<'_>) -> Result<(), Error> {
         .map(|token| {
             (
                 token.0.clone(),
-                format!("{}/{}", token.1.name, token.1.owner),
+                format!("{}/{}", token.1.owner, token.1.name),
                 true,
             )
         })

--- a/src/events/issue.rs
+++ b/src/events/issue.rs
@@ -107,8 +107,7 @@ async fn issue_embeds(data: &Data, message: &Message) -> Option<Vec<CreateEmbed>
     let client = octocrab::instance();
     let ratelimit = client.ratelimit();
 
-    let regex =
-        Regex::new(r#" ?([a-zA-Z0-9-_.]+)?#([0-9]+) ?"#).expect("Expected numbers regex");
+    let regex = Regex::new(r#" ?([a-zA-Z0-9-_.]+)?#([0-9]+) ?"#).expect("Expected numbers regex");
 
     let custom_repos = { data.state.read().unwrap().issue_prefixes.clone() };
 

--- a/src/events/issue.rs
+++ b/src/events/issue.rs
@@ -108,7 +108,7 @@ async fn issue_embeds(data: &Data, message: &Message) -> Option<Vec<CreateEmbed>
     let ratelimit = client.ratelimit();
 
     let regex =
-        Regex::new(r#" ?([a-zA-Z0-9-_.]+)?#([0-9]+[0-9]) ?"#).expect("Expected numbers regex");
+        Regex::new(r#" ?([a-zA-Z0-9-_.]+)?#([0-9]+) ?"#).expect("Expected numbers regex");
 
     let custom_repos = { data.state.read().unwrap().issue_prefixes.clone() };
 
@@ -126,7 +126,9 @@ async fn issue_embeds(data: &Data, message: &Message) -> Option<Vec<CreateEmbed>
 
                     issues = client.issues(owner, repo);
                     prs = client.pulls(owner, repo);
-                }
+                } else {
+                    continue; // discards when it doesn't match a repo.
+                };
             }
 
             let ratelimit = ratelimit


### PR DESCRIPTION
second time around hopefully things are better now.

Everything I mention below should get an answer because I can't read minds.

Do we consider this to fix #8 (not the best solution, but it does block things that fall under the regex but do not match a repository)

With the addition of repo tokens it is now "harder" to have a proper solution. I *could* add support for everything but whitespace & "#" and it'll basically eliminate the problem in 100% of all situations, but the current solution will basically work in 99.5% of situations. The only problem in #8 is that links with #num at the end get caught but characters that are matched by the regex are before that and therefore the issue is gone.

Due to the addition of a button to remove issue responses, I have allowed single digit matching again so you no longer have to put 08 to link an issue with a single digit id, I have no idea if this is wanted.


