### PR TITLE
Fix edit remove snippets

### DIFF
--- a/src/commands/snippets.rs
+++ b/src/commands/snippets.rs
@@ -144,15 +144,16 @@ pub async fn remove_snippet(
     ctx: Context<'_>,
     #[autocomplete = "autocomplete_snippet"]
     #[description = "The snippet's id"]
-    id: String,
+    #[rename = "id"]
+    id_and_title: String,
 ) -> Result<(), Error> {
-    match get_snippet_lazy(&ctx, &id) {
+    match get_snippet(&ctx, &id_and_title) {
         Some(snippet) => {
             remove_snippet_confirm(&ctx, &snippet).await?;
         }
         None => {
             let title = &"Failed to remove snippet";
-            let content = &&format!("The snippet '{id}' does not exist");
+            let content = &&format!("The snippet '{id_and_title}' does not exist");
             respond_err(&ctx, title, content).await;
         }
     }

--- a/src/commands/snippets.rs
+++ b/src/commands/snippets.rs
@@ -102,11 +102,12 @@ pub async fn edit_snippet(
     ctx: Context<'_>,
     #[autocomplete = "autocomplete_snippet"]
     #[description = "The snippet's id"]
-    id: String,
+    #[rename = "id"]
+    id_and_title: String,
     #[description = "The snippet's title"] title: Option<String>,
     #[description = "The snippet's content"] content: Option<String>,
 ) -> Result<(), Error> {
-    match get_snippet_lazy(&ctx, &id) {
+    match get_snippet(&ctx, &id_and_title) {
         Some(mut snippet) => {
             if let Some(title) = title {
                 snippet.title = title;
@@ -118,7 +119,8 @@ pub async fn edit_snippet(
 
             {
                 let mut rwlock_guard = ctx.data().state.write().unwrap();
-                rwlock_guard.snippets.push(snippet.clone());
+                let editing_snippet = rwlock_guard.snippets.iter_mut().find(|s| s.format_output().eq(&id_and_title)).unwrap();
+                *editing_snippet = snippet.clone();
                 println!("Snippet edited '{}: {}'", snippet.title, snippet.content);
                 rwlock_guard.write();
             }
@@ -128,7 +130,7 @@ pub async fn edit_snippet(
         }
         None => {
             let title = &"Failed to edit snippet";
-            let content = &&format!("The snippet '{id}' does not exist");
+            let content = &&format!("The snippet '{id_and_title}' does not exist");
             respond_err(&ctx, title, content).await;
         }
     };
@@ -234,7 +236,7 @@ impl Embeddable for Snippet {
 }
 
 // Exact matches the snippet id and name.
-fn _get_snippet(ctx: &Context<'_>, id: &str) -> Option<Snippet> {
+fn get_snippet(ctx: &Context<'_>, id: &str) -> Option<Snippet> {
     let data = ctx.data();
     let rwlock_guard = data.state.read().unwrap();
 


### PR DESCRIPTION
Fixes #52 and somewhat #53

The result of `autocomplete_snippet` is the id and title, not the id. So using `get_snippet` instead of `get_snippet_lazy` is possible here. Edit and remove snippet are also slash command only so this doesnt create an issue for trying to use it as a prefix command.

If there's a snippet with both the same id and title, this wont help but that isnt supposed to be possible.

Edit snippet now actually edits the snippet instead of creating a new snippet.